### PR TITLE
Fix pytest import pipa module error in Makefile when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clean lint test build uninstall install
+all: clean lint build uninstall install test
 
 build:
 	python -m build


### PR DESCRIPTION
# Fix
Fix pytest import pipa module error in Makefile when installing

```bash
ImportError while importing test module '/home/hzxie/gits/pipa/test/test_cmd.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../softwares/miniconda/envs/pipa/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/test_cmd.py:1: in <module>
    from pipa.common.cmd import run_command
E   ModuleNotFoundError: No module named 'pipa'
```