### PR TITLE
Install protobuf dep in project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pandarallel",
     "seaborn",
     "psutil",
+    "protobuf",
     "grpcio",
     "requests",
     "scipy",


### PR DESCRIPTION
# Fix
 - Fix module not found in pipad (Add protobuf dep).
 
Error log:

```bash
royenheart@RoyenHeartFedora:~/gits/CommonOperations/commopts/cfg$ pipa generate
Traceback (most recent call last):
  File "/usr/local/bin/pipa", line 5, in <module>
    from pipa.main import main
  File "/usr/local/lib/python3.12/site-packages/pipa/main.py", line 4, in <module>
    from pipa.service.upload import main as pipa_upload
  File "/usr/local/lib/python3.12/site-packages/pipa/service/upload.py", line 6, in <module>
    from pipa.service.pipad.pipad_client import PIPADClient
  File "/usr/local/lib/python3.12/site-packages/pipa/service/pipad/pipad_client.py", line 75, in <module>
    from . import pipad_pb2 as pipadlib
  File "/usr/local/lib/python3.12/site-packages/pipa/service/pipad/pipad_pb2.py", line 6, in <module>
    from google.protobuf import descriptor as _descriptor
ModuleNotFoundError: No module named 'google'
```