### PR TITLE
Enhance simple clustering func and fix some bugs

### DIFF
--- a/src/pipa/parser/perf_script_call.py
+++ b/src/pipa/parser/perf_script_call.py
@@ -224,7 +224,7 @@ class PerfScriptData:
     """
 
     def __init__(self, blocks: list[PerfScriptBlock]):
-        self.blocks: PerfScriptBlock = blocks
+        self.blocks: list[PerfScriptBlock] = blocks
 
     def __str__(self):
         return f"{self.blocks}"
@@ -340,4 +340,4 @@ class PerfScriptData:
             pd.DataFrame: A pandas DataFrame containing the records from the blocks.
         """
 
-        return pd.DataFrame([self.blocks.to_record()])
+        return pd.DataFrame([b.to_record() for b in self.blocks])

--- a/src/pipa/service/call_graph.py
+++ b/src/pipa/service/call_graph.py
@@ -604,7 +604,7 @@ class CallGraph:
             json.dump(_clusters, file, cls=ClusterEncoder, indent=4)
 
         # Use viridis colors for mapping
-        color_map = plt.cm.get_cmap("viridis", len(attrs_groups))
+        color_map = plt.get_cmap("viridis", len(attrs_groups))
 
         # Set color for the group results
         node_colors = [color_map(nodes[node]["cluster"]) for node in nodes]


### PR DESCRIPTION
# Fix
- plt.cm.get_cmap deprecated in matplotlib 3.9, change to pyplot.get_cmap
- Fix array index error in to_raw_dataframe() func
# Feat
- Use a more stable approach to clustering and layout