### PR TITLE
Enhance cfg info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,9 @@ dependencies = [
     "requests",
     "scipy",
     "networkx",
-    "matplotlib"
+    "matplotlib",
+    "pyelftools",
+    "capstone",
 ]
 
 [project.optional-dependencies]

--- a/src/pipa/common/utils.py
+++ b/src/pipa/common/utils.py
@@ -1,6 +1,24 @@
 import datetime
+from math import sqrt
 import sys
+from typing import Tuple
 from rich import print
+
+
+def find_closet_factor_pair(n: int) -> Tuple[int, int]:
+    """
+    Find closet fator pair of n
+
+    Args:
+        n (int): number to find
+
+    Returns:
+        Tuple[int, int]: (small factor A, large factor B), A * B = n
+    """
+    m = int(sqrt(n))
+    while n % m != 0:
+        m -= 1
+    return (m, int(n / m))
 
 
 def get_timestamp():

--- a/src/pipa/service/call_graph.py
+++ b/src/pipa/service/call_graph.py
@@ -608,20 +608,18 @@ class CallGraph:
         nodes = G.nodes
 
         # create groups
-        attrs_groups = {}
+        attrs_groups = defaultdict(lambda: [])
         for node in nodes:
             attr = f"{node.module_name}"
-            if attr not in attrs_groups:
-                attrs_groups[attr] = []
             attrs_groups[attr].append(node)
         attrs_to_cluster = {attr: idx for idx, attr in enumerate(attrs_groups.keys())}
 
         # assign cluster & Combine Data
         _clusters = defaultdict(lambda: {"cycles": 0, "insts": 0, "funcs": []})
-        for node in nodes:
+        for node, node_v in nodes.items():
             attr = f"{node.module_name}"
             _cluster = attrs_to_cluster[attr]
-            nodes[node]["cluster"] = _cluster
+            node_v["cluster"] = _cluster
             _clusters[_cluster]["cycles"] += node.get_cycles()
             _clusters[_cluster]["insts"] += node.get_instructions()
             _clusters[_cluster]["funcs"].extend(node.nodes)  # type: ignore
@@ -633,9 +631,9 @@ class CallGraph:
         color_map = plt.get_cmap("viridis", len(attrs_groups))
 
         # set color for the group results
-        node_colors = [color_map(nodes[node]["cluster"]) for node in nodes]
-        for i, node in enumerate(nodes):
-            nodes[node]["color"] = node_colors[i]
+        node_colors = [color_map(node_v["cluster"]) for node_v in nodes.values()]
+        for i, node_v in enumerate(nodes.values()):
+            node_v["color"] = node_colors[i]
 
         # fetch each node's position
         # group nodes


### PR DESCRIPTION
# Feature
- Add  extended performance metrics info (include source codes mapping, etc.) in FuncnodeTable

    Test codes:
```python
from pipa.parser.perf_script_call import PerfScriptData
from pipa.service.call_graph import NodeTable, FunctionNodeTable
import networkx as nx
import matplotlib.pyplot as plt
import pandas as pd
from pipa.common.logger import logger, stream_handler, logging

perf_script = PerfScriptData.from_file(
    "./perf.script"
)

logger.setLevel(logging.DEBUG)
stream_handler.setLevel(logging.DEBUG)

func_graph = nx.DiGraph()
node_graph = nx.DiGraph()

node_table = NodeTable.from_perf_script_data(perf_script)

import pipa.service.call_graph as pipa_cfg
pipa_cfg.NUM_ADDR2LINE_PROCESS = 80
pipa_cfg.ADDR2LINE_OPT_STRENGTH = 2e8
func_table = FunctionNodeTable.from_node_table(node_table)

for func_node in func_table.function_nodes.values():
    if func_node.node_infos:
        for ni in func_node.node_infos:
            addr, addr_ips, addr_cycles, addr_line, addr_column, addr_mnemonic, addr_op_str, addr_conts, source_file = ni
            if addr_cycles > 0:
                print(f"{addr} | {addr_ips}, {addr_cycles} | {addr_line}, {addr_column} | {addr_mnemonic}, {addr_op_str} | {addr_conts} {source_file}".strip())
```
# Build
- Add pyelftools / capstone deps
# Perf
- Remove duplicate index operations in simple_groups