### PR TITLE
feat: add remote profiling support via SSH with sar and perf tools

### DIFF
--- a/asset/config-remote-profile.yaml
+++ b/asset/config-remote-profile.yaml
@@ -1,0 +1,35 @@
+# Configuration template for PIPA remote SSH profiling
+# Command Example: pipa remote_profile --config_path=./config-remote-profile.yaml
+
+# SSH Connection Settings
+host: 0.0.0.0              # IP address or hostname of the remote machine
+username: root                   # SSH username
+port: 22                         # SSH port (default: 22)
+# Authentication (use one of the following methods)
+password: password123            # SSH password (for password authentication)
+#key_path: ~/.ssh/id_rsa         # Path to SSH private key file (for key authentication)
+
+# Profiling Configuration
+profiling_mode: sar              # Profiling mode: sar, perf_stat, or perf_record
+
+# Workload Configuration
+workload_command: perf bench futex hash     # Command to execute as the workload on remote machine
+
+# Output Configuration
+local_output_dir: ./remote_profile_output  # Local directory to store results
+remote_output_dir: /tmp/pipa_remote_profile  # Remote directory for temporary files
+cleanup_remote: true             # Whether to clean up remote files after profiling
+
+# Mode-specific Configuration
+# For sar mode
+sar_interval: 1                  # Sampling interval in seconds
+sar_count: all                   # Number of samples to collect (use "all" for continuous collection until workload finishes)
+
+# Mode-specific Configuration, 3 of them are Optional
+# For perf_stat mode
+perf_stat_events: "cycles,instructions,cache-misses"  # Events to collect with perf stat
+
+# For perf_record mode
+perf_record_events: "{cycles,instructions}:S"  # Events to collect with perf record
+perf_record_freq: 999            # Sampling frequency for perf record
+perf_record_callgraph: true      # Whether to capture call graphs with -g

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
     "pyelftools",
     "capstone",
     "plotly",
-    "nbformat"
+    "nbformat",
+    "paramiko"
 ]
 
 [project.optional-dependencies]

--- a/src/pipa/main.py
+++ b/src/pipa/main.py
@@ -5,6 +5,7 @@ from pipa.service.export_sys_config import run_export_config_script
 from pipa.service.upload import main as pipa_upload
 from pipa.service.dump import dump as pipa_dump
 from pipa.service.archive import archive as pipa_archive
+from pipa.service.remote import remote as pipa_remote_profile
 from pipa.common.utils import handle_user_cancelled
 from pipa.common.logger import logger, set_level
 from pipa.__about__ import __version__
@@ -62,6 +63,11 @@ class PipaCLI:
         # Dump PIPASHU overview data to a file
         pipa_dump(output_path, config_path, verbose)
 
+    @handle_user_cancelled
+    def remote(self, config_path: str = None, verbose: bool = False):
+        # Profile applications on a remote machine via SSH
+        pipa_remote_profile(config_path, verbose)
+
     def archive(
         self,
         perf_data: str = "perf.data",
@@ -89,6 +95,7 @@ class PipaCLI:
         print("  pipa upload")
         print("  pipa dump")
         print("  pipa archive")
+        print("  pipa remote")
         print("  pipa version")
         print("  pipa help")
         print("Options:")
@@ -97,6 +104,7 @@ class PipaCLI:
         print("  upload    Upload the performance data to PIPAD server")
         print("  dump      Dump PIPASHU overview data to a file")
         print("  archive   Archive buildid and source files")
+        print("  remote  Profile applications on a remote machine via SSH")
         print("  version   Show the version of PIPA")
         print("  help      Show this help message and exit")
 

--- a/src/pipa/service/remote.py
+++ b/src/pipa/service/remote.py
@@ -1,0 +1,464 @@
+import os
+import yaml
+import time
+import logging
+import paramiko
+from pathlib import Path
+from typing import Dict
+from pipa.common.logger import logger
+
+
+class RemoteProfiler:
+    """
+    RemoteProfiler provides functionality to profile applications on a remote machine via SSH.
+    """
+
+    def __init__(self, config_path: str):
+        """
+        Initialize the RemoteProfiler with configuration from a file.
+
+        Args:
+            config_path (str): Path to the YAML configuration file.
+        """
+        self.config = self._load_config(config_path)
+        self.ssh_client = None
+        self.profiling_mode = self.config.get("profiling_mode", "sar")
+        self.output_dir = Path(
+            self.config.get("local_output_dir", "./remote_profile_output")
+        )
+        self.remote_output_dir = self.config.get(
+            "remote_output_dir", "/tmp/pipa_remote_profile"
+        )
+        self.workload_command = self.config.get("workload_command", "")
+
+        # Create local output directory if it doesn't exist
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def _load_config(self, config_path: str) -> dict:
+        """
+        Load configuration from YAML file.
+
+        Args:
+            config_path (str): Path to the YAML configuration file.
+
+        Returns:
+            dict: Configuration dictionary.
+
+        Raises:
+            FileNotFoundError: If config file doesn't exist.
+            yaml.YAMLError: If config file isn't valid YAML.
+        """
+        if not os.path.exists(config_path):
+            logger.error(f"Configuration file {config_path} not found.")
+            raise FileNotFoundError(f"Configuration file {config_path} not found.")
+
+        try:
+            with open(config_path, "r") as f:
+                config = yaml.safe_load(f)
+
+            # Validate required configuration
+            required_fields = ["host", "username"]
+            missing_fields = [field for field in required_fields if field not in config]
+
+            if missing_fields:
+                error_msg = f"Missing required configuration fields: {', '.join(missing_fields)}"
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            return config
+        except yaml.YAMLError as e:
+            logger.error(f"Error parsing configuration file: {e}")
+            raise
+
+    def connect(self) -> bool:
+        """
+        Connect to the remote machine via SSH.
+
+        Returns:
+            bool: True if connection successful, False otherwise.
+        """
+        self.ssh_client = paramiko.SSHClient()
+        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        try:
+            host = self.config["host"]
+            username = self.config["username"]
+            password = self.config.get("password")
+            key_path = self.config.get("key_path")
+            port = self.config.get("port", 22)
+
+            if key_path and os.path.exists(key_path):
+                logger.info(f"Connecting to {host} using SSH key authentication")
+                self.ssh_client.connect(
+                    hostname=host, username=username, key_filename=key_path, port=port
+                )
+            elif password:
+                logger.info(f"Connecting to {host} using password authentication")
+                self.ssh_client.connect(
+                    hostname=host, username=username, password=password, port=port
+                )
+            else:
+                logger.error(
+                    "No authentication method provided. Need either password or key_path."
+                )
+                return False
+
+            logger.info(f"Successfully connected to {host}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to connect to remote host: {e}")
+            return False
+
+    def check_remote_tools(self) -> Dict[str, bool]:
+        """
+        Check if required profiling tools are available on the remote machine.
+
+        Returns:
+            Dict[str, bool]: Dictionary of tool availability.
+        """
+        if not self.ssh_client:
+            logger.error("Not connected to remote host. Call connect() first.")
+            return {"connected": False}
+
+        tools_availability = {"connected": True, "sar": False, "perf": False}
+
+        # Check for sar
+        _, stdout, _ = self.ssh_client.exec_command("which sar")
+        tools_availability["sar"] = stdout.read().decode().strip() != ""
+
+        # Check for perf
+        _, stdout, _ = self.ssh_client.exec_command("which perf")
+        tools_availability["perf"] = stdout.read().decode().strip() != ""
+
+        logger.info(f"Remote tools availability: {tools_availability}")
+        return tools_availability
+
+    def setup_remote_environment(self) -> bool:
+        """
+        Setup the remote environment for profiling.
+
+        Returns:
+            bool: True if setup successful, False otherwise.
+        """
+        if not self.ssh_client:
+            logger.error("Not connected to remote host. Call connect() first.")
+            return False
+
+        # Create remote output directory if it doesn't exist
+        _, stdout, stderr = self.ssh_client.exec_command(
+            f"mkdir -p {self.remote_output_dir}"
+        )
+        exit_code = stdout.channel.recv_exit_status()
+
+        if exit_code != 0:
+            logger.error(
+                f"Failed to create remote output directory: {stderr.read().decode()}"
+            )
+            return False
+
+        logger.info(
+            f"Remote environment setup complete. Output directory: {self.remote_output_dir}"
+        )
+        return True
+
+    def run_profiling(self) -> bool:
+        """
+        Run the selected profiling mode on the remote machine.
+
+        Returns:
+            bool: True if profiling successful, False otherwise.
+        """
+        if not self.ssh_client:
+            logger.error("Not connected to remote host. Call connect() first.")
+            return False
+
+        # Check if the remote environment is ready
+        if not self.setup_remote_environment():
+            return False
+
+        # Generate a timestamp for this profiling run
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+
+        # Run the appropriate profiling command based on the selected mode
+        if self.profiling_mode == "sar":
+            return self._run_sar_profiling(timestamp)
+        elif self.profiling_mode == "perf_stat":
+            return self._run_perf_stat_profiling(timestamp)
+        elif self.profiling_mode == "perf_record":
+            return self._run_perf_record_profiling(timestamp)
+        else:
+            logger.error(f"Unsupported profiling mode: {self.profiling_mode}")
+            return False
+
+    def _run_sar_profiling(self, timestamp: str) -> bool:
+        """
+        Run system-wide statistics profiling with sar.
+
+        Args:
+            timestamp (str): Timestamp string for output files.
+
+        Returns:
+            bool: True if profiling successful, False otherwise.
+        """
+        interval = self.config.get("sar_interval", 1)
+        count = self.config.get("sar_count", "all")
+        output_file = f"{self.remote_output_dir}/sar-{timestamp}.log"
+
+        # Construct the sar command
+        if count == "all":
+            # Run sar in background and capture all metrics until workload finishes
+            sar_cmd = (
+                f"sar -A {interval} -o {output_file} > /dev/null 2>&1 & SAR_PID=$!;"
+            )
+            workload_cmd = f"{self.workload_command}; WORKLOAD_EXIT=$?;"
+            kill_cmd = "kill -TERM $SAR_PID;"
+            final_cmd = f"{sar_cmd} {workload_cmd} {kill_cmd} exit $WORKLOAD_EXIT"
+        else:
+            # Run sar for a specific number of samples
+            sar_cmd = f"sar -A {interval} {count} -o {output_file} > {output_file}.txt 2>&1 & SAR_PID=$!;"
+            workload_cmd = f"{self.workload_command}; WORKLOAD_EXIT=$?;"
+            wait_cmd = "wait $SAR_PID;"
+            final_cmd = f"{sar_cmd} {workload_cmd} {wait_cmd} exit $WORKLOAD_EXIT"
+
+        logger.info(f"Running sar profiling with command: {final_cmd}")
+
+        # Execute the command
+        _, stdout, stderr = self.ssh_client.exec_command(final_cmd)
+        exit_code = stdout.channel.recv_exit_status()
+
+        if exit_code != 0:
+            logger.error(
+                f"sar profiling failed with exit code {exit_code}: {stderr.read().decode()}"
+            )
+            return False
+
+        # Transfer the results back
+        return self._transfer_results(f"{output_file}*", timestamp)
+
+    def _run_perf_stat_profiling(self, timestamp: str) -> bool:
+        """
+        Run aggregate counter profiling with perf stat.
+
+        Args:
+            timestamp (str): Timestamp string for output files.
+
+        Returns:
+            bool: True if profiling successful, False otherwise.
+        """
+        output_file = f"{self.remote_output_dir}/perf-stat-{timestamp}.log"
+        events = self.config.get("perf_stat_events", "cycles,instructions")
+
+        # Construct the perf stat command
+        perf_cmd = f"perf stat -e {events} -o {output_file} {self.workload_command}"
+
+        logger.info(f"Running perf stat profiling with command: {perf_cmd}")
+
+        # Execute the command
+        _, stdout, stderr = self.ssh_client.exec_command(perf_cmd)
+        exit_code = stdout.channel.recv_exit_status()
+
+        if exit_code != 0:
+            logger.error(
+                f"perf stat profiling failed with exit code {exit_code}: {stderr.read().decode()}"
+            )
+            return False
+
+        # Transfer the results back
+        return self._transfer_results(output_file, timestamp)
+
+    def _run_perf_record_profiling(self, timestamp: str) -> bool:
+        """
+        Run detailed sampling profiling with perf record.
+
+        Args:
+            timestamp (str): Timestamp string for output files.
+
+        Returns:
+            bool: True if profiling successful, False otherwise.
+        """
+        output_file = f"{self.remote_output_dir}/perf-{timestamp}.data"
+        events = self.config.get("perf_record_events", "{cycles,instructions}:S")
+        freq = self.config.get("perf_record_freq", 999)
+        callgraph = self.config.get("perf_record_callgraph", False)
+
+        # Construct the perf record command
+        call_graph_opt = "-g" if callgraph else ""
+        perf_cmd = f"perf record -e {events} -F {freq} {call_graph_opt} -o {output_file} {self.workload_command}"
+
+        logger.info(f"Running perf record profiling with command: {perf_cmd}")
+
+        # Execute the command
+        _, stdout, stderr = self.ssh_client.exec_command(perf_cmd)
+        exit_code = stdout.channel.recv_exit_status()
+
+        if exit_code != 0:
+            logger.error(
+                f"perf record profiling failed with exit code {exit_code}: {stderr.read().decode()}"
+            )
+            return False
+
+        # Transfer the results back
+        return self._transfer_results(output_file, timestamp)
+
+    def _transfer_results(self, remote_pattern: str, timestamp: str) -> bool:
+        """
+        Transfer profiling results from remote to local machine.
+
+        Args:
+            remote_pattern (str): Pattern matching remote files to transfer.
+            timestamp (str): Timestamp string for organizing output files.
+
+        Returns:
+            bool: True if transfer successful, False otherwise.
+        """
+        try:
+            # Create a timestamped directory for this run's results
+            local_dir = os.path.join(self.output_dir, timestamp)
+            os.makedirs(local_dir, exist_ok=True)
+
+            # Open an SFTP session
+            sftp = self.ssh_client.open_sftp()
+
+            # List files matching the pattern
+            _, stdout, _ = self.ssh_client.exec_command(
+                f"ls -1 {remote_pattern} 2>/dev/null || echo ''"
+            )
+            files = stdout.read().decode().strip().split("\n")
+            files = [f for f in files if f]  # Filter out empty strings
+
+            if not files:
+                logger.warning(f"No files found matching pattern {remote_pattern}")
+                return False
+
+            # Transfer each file
+            for remote_file in files:
+                filename = os.path.basename(remote_file)
+                local_file = os.path.join(local_dir, filename)
+                logger.info(f"Transferring {remote_file} to {local_file}")
+                sftp.get(remote_file, local_file)
+
+            sftp.close()
+            logger.info(f"Successfully transferred profiling results to {local_dir}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to transfer profiling results: {e}")
+            return False
+
+    def disconnect(self):
+        """
+        Disconnect from the remote machine.
+        """
+        if self.ssh_client:
+            self.ssh_client.close()
+            self.ssh_client = None
+            logger.info("Disconnected from remote host")
+
+    def cleanup_remote(self) -> bool:
+        """
+        Clean up temporary files on the remote machine.
+
+        Returns:
+            bool: True if cleanup successful, False otherwise.
+        """
+        if not self.ssh_client:
+            logger.error("Not connected to remote host. Call connect() first.")
+            return False
+
+        # Remove the remote output directory if configured to do so
+        if self.config.get("cleanup_remote", True):
+            _, stdout, stderr = self.ssh_client.exec_command(
+                f"rm -rf {self.remote_output_dir}"
+            )
+            exit_code = stdout.channel.recv_exit_status()
+
+            if exit_code != 0:
+                logger.error(
+                    f"Failed to clean up remote files: {stderr.read().decode()}"
+                )
+                return False
+
+            logger.info("Remote cleanup completed successfully")
+        return True
+
+
+def remote(config_path: str = None, verbose: bool = False):
+    """
+    Main entry point for the remote profiling service.
+
+    Args:
+        config_path (str, optional): Path to the configuration file. Defaults to None.
+        verbose (bool, optional): Enable verbose logging. Defaults to False.
+
+    Returns:
+        bool: True if profiling successful, False otherwise.
+    """
+    import questionary
+    from rich import print
+
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    # If config_path is not provided, prompt the user
+    if config_path is None:
+        config_path = questionary.text(
+            "Path to remote profiling configuration file:"
+        ).ask()
+
+        if not config_path:
+            logger.error("No configuration file provided. Exiting.")
+            return False
+
+    try:
+        # Initialize the remote profiler
+        profiler = RemoteProfiler(config_path)
+
+        # Connect to the remote host
+        if not profiler.connect():
+            logger.error(
+                "Failed to connect to remote host. Check your SSH credentials."
+            )
+            return False
+
+        # Check for available tools
+        tools = profiler.check_remote_tools()
+        if not tools["connected"]:
+            logger.error("Not connected to remote host.")
+            return False
+
+        if profiler.profiling_mode == "sar" and not tools["sar"]:
+            logger.error(
+                "'sar' tool not found on remote host but sar profiling mode is selected."
+            )
+            return False
+
+        if (
+            profiler.profiling_mode in ["perf_stat", "perf_record"]
+            and not tools["perf"]
+        ):
+            logger.error(
+                "'perf' tool not found on remote host but perf profiling mode is selected."
+            )
+            return False
+
+        print(f"[green]✓[/green] Remote profiling tools availability: {tools}")
+
+        # Run the profiling
+        success = profiler.run_profiling()
+
+        if success:
+            print("[green]✓[/green] Remote profiling completed successfully.")
+        else:
+            print("[red]✗[/red] Remote profiling failed.")
+
+        # Clean up
+        profiler.cleanup_remote()
+        profiler.disconnect()
+
+        return success
+
+    except Exception as e:
+        logger.error(f"Error during remote profiling: {e}")
+        return False

--- a/test/test_service_remote.py
+++ b/test/test_service_remote.py
@@ -1,0 +1,246 @@
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+
+from pipa.service.remote import RemoteProfiler, remote
+
+
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"')
+@patch("os.path.exists")
+def test_remote_profiler_init(mock_exists, mock_file):
+    """Test initialization of the RemoteProfiler class"""
+    mock_exists.return_value = True
+    profiler = RemoteProfiler("dummy_config.yaml")
+    
+    # Verify that the configuration file is loaded correctly
+    mock_file.assert_called_once_with("dummy_config.yaml", "r")
+    
+    # Verify that the basic properties are set correctly
+    assert profiler.config["host"] == "test-host"
+    assert profiler.config["username"] == "test-user"
+    assert profiler.ssh_client is None
+    assert profiler.profiling_mode == "sar"  # Default mode
+
+
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"')
+@patch("os.path.exists")
+def test_load_config_success(mock_exists, mock_file):
+    """Test successful loading of the configuration file"""
+    mock_exists.return_value = True
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    config = profiler.config
+    
+    assert config["host"] == "test-host"
+    assert config["username"] == "test-user"
+
+
+@patch("os.path.exists")
+def test_load_config_file_not_found(mock_exists):
+    """Test the case where the configuration file does not exist"""
+    mock_exists.return_value = False
+    
+    with pytest.raises(FileNotFoundError):
+        RemoteProfiler("non_existent_config.yaml")
+
+
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"')
+@patch("os.path.exists")
+def test_load_config_missing_fields(mock_exists, mock_file):
+    """Test the case where the configuration file is missing required fields"""
+    mock_exists.return_value = True
+    
+    with pytest.raises(ValueError):
+        RemoteProfiler("incomplete_config.yaml")
+
+
+@patch("paramiko.SSHClient")
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"\npassword: "test-pass"')
+@patch("os.path.exists")
+def test_connect_with_password(mock_exists, mock_file, mock_ssh):
+    """Test connecting to the remote host using a password"""
+    mock_exists.return_value = True
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    result = profiler.connect()
+    
+    assert result is True
+    mock_client.connect.assert_called_once_with(
+        hostname="test-host",
+        username="test-user",
+        password="test-pass",
+        port=22
+    )
+
+
+@patch("paramiko.SSHClient")
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"\nkey_path: "/path/to/key.pem"')
+@patch("os.path.exists")
+def test_connect_with_key(mock_exists, mock_file, mock_ssh):
+    """Test connecting to the remote host using a key"""
+    mock_exists.side_effect = [True, True]  # Configuration file exists, key file exists
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    result = profiler.connect()
+    
+    assert result is True
+    mock_client.connect.assert_called_once_with(
+        hostname="test-host",
+        username="test-user",
+        key_filename="/path/to/key.pem",
+        port=22
+    )
+
+
+@patch("paramiko.SSHClient")
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"')
+@patch("os.path.exists")
+def test_connect_no_auth(mock_exists, mock_file, mock_ssh):
+    """Test the case where no authentication method is provided"""
+    mock_exists.return_value = True
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    result = profiler.connect()
+    
+    assert result is False
+    mock_client.connect.assert_not_called()
+
+
+@patch("paramiko.SSHClient")
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"\npassword: "test-pass"')
+@patch("os.path.exists")
+def test_check_remote_tools(mock_exists, mock_file, mock_ssh):
+    """Test checking the availability of remote tools"""
+    mock_exists.return_value = True
+    
+    # Mock SSH client and command execution
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    
+    # Mock command execution results
+    mock_stdout_sar = MagicMock()
+    mock_stdout_sar.channel.recv_exit_status.return_value = 0
+    
+    mock_stdout_perf = MagicMock()
+    mock_stdout_perf.channel.recv_exit_status.return_value = 0
+    
+    mock_client.exec_command.side_effect = [
+        (None, mock_stdout_sar, None),  # sar command
+        (None, mock_stdout_perf, None),  # perf command
+    ]
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    profiler.ssh_client = mock_client
+    
+    result = profiler.check_remote_tools()
+    
+    assert result["connected"] is True
+    assert result["sar"] is True
+    assert result["perf"] is True
+    assert mock_client.exec_command.call_count == 2
+
+
+@patch("paramiko.SSHClient")
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"\npassword: "test-pass"\ncleanup_remote: true')
+@patch("os.path.exists")
+def test_cleanup_remote(mock_exists, mock_file, mock_ssh):
+    """Test the remote cleanup functionality"""
+    mock_exists.return_value = True
+    
+    # Mock SSH client and command execution
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    
+    mock_stdout = MagicMock()
+    mock_stdout.channel.recv_exit_status.return_value = 0
+    mock_client.exec_command.return_value = (None, mock_stdout, None)
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    profiler.ssh_client = mock_client
+    
+    result = profiler.cleanup_remote()
+    
+    assert result is True
+    mock_client.exec_command.assert_called_once_with(f"rm -rf {profiler.remote_output_dir}")
+
+
+@patch("paramiko.SSHClient")
+@patch("builtins.open", new_callable=mock_open, read_data='host: "test-host"\nusername: "test-user"\npassword: "test-pass"')
+@patch("os.path.exists")
+def test_disconnect(mock_exists, mock_file, mock_ssh):
+    """Test the disconnect functionality"""
+    mock_exists.return_value = True
+    
+    # Mock SSH client
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    
+    profiler = RemoteProfiler("dummy_config.yaml")
+    profiler.ssh_client = mock_client
+    
+    profiler.disconnect()
+    
+    mock_client.close.assert_called_once()
+    assert profiler.ssh_client is None
+
+
+@patch("pipa.service.remote.RemoteProfiler")
+@patch("questionary.text")
+def test_remote_main_function(mock_text, mock_remote_profiler):
+    """Test the main entry function of the remote service"""
+    mock_text.return_value.ask.return_value = "dummy_config.yaml"
+    
+    # Mock RemoteProfiler instance
+    mock_profiler = MagicMock()
+    mock_remote_profiler.return_value = mock_profiler
+    
+    # Set the return values for each method
+    mock_profiler.connect.return_value = True
+    mock_profiler.check_remote_tools.return_value = {
+        "connected": True,
+        "sar": True,
+        "perf": True
+    }
+    mock_profiler.run_profiling.return_value = True
+    
+    # Execute the test
+    result = remote(verbose=True)
+    
+    assert result is True
+    mock_profiler.connect.assert_called_once()
+    mock_profiler.check_remote_tools.assert_called_once()
+    mock_profiler.run_profiling.assert_called_once()
+    mock_profiler.cleanup_remote.assert_called_once()
+    mock_profiler.disconnect.assert_called_once()
+
+
+@patch("pipa.service.remote.RemoteProfiler")
+def test_remote_with_provided_config(mock_remote_profiler):
+    """Test the case where a configuration file path is provided"""
+    # Mock RemoteProfiler instance
+    mock_profiler = MagicMock()
+    mock_remote_profiler.return_value = mock_profiler
+    
+    # Set the return values for each method
+    mock_profiler.connect.return_value = True
+    mock_profiler.check_remote_tools.return_value = {
+        "connected": True,
+        "sar": True,
+        "perf": True
+    }
+    mock_profiler.run_profiling.return_value = True
+    
+    # Execute the test
+    result = remote(config_path="provided_config.yaml")
+    
+    assert result is True
+    mock_remote_profiler.assert_called_once_with("provided_config.yaml")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__])


### PR DESCRIPTION
# Remote Profiling Support via SSH with sar and perf tools

## Feature Overview

This PR adds remote profiling capabilities to pipa, allowing users to profile applications on remote machines through SSH connections using industry-standard tools like `sar` and `perf`. This extends pipa's functionality beyond local profiling, enabling distributed application performance analysis.

## Usage

### Basic Usage

```bash
pipa remote --config_path=./config-remote-profile.yaml
```

### Configuration Example

```yaml
# SSH Connection Settings
host: remote-server.example.com
username: user
password: password123  # Or use key_path for key-based auth

# Profiling Configuration
profiling_mode: sar    # Options: sar, perf_stat, perf_record

# Workload Configuration
workload_command: ./my_application --benchmark

# Output Configuration
local_output_dir: ./remote_profile_output
```

## Requirements

- Paramiko Python package for SSH connectivity
- Target remote machine must have:
  - SSH server running
  - `sar` tool installed (for sar mode)
  - `perf` tool installed (for perf_stat or perf_record modes)

## Testing

A comprehensive test suite is included that covers:
- Configuration loading
- SSH connection handling with both password and key authentication
- Remote tool detection
- Profiling execution
- Result transfer
- Cleanup operations
