### PR TITLE
fix(generate): Fix silent crash in script generation by passing missing argument

### DIFF
--- a/src/pipa/service/gengerate/run_by_pipa.py
+++ b/src/pipa/service/gengerate/run_by_pipa.py
@@ -105,6 +105,7 @@ def generate(config):
             )
         else:
             perf_stat_cmd = build_perf_stat_cmd(
+                workspace=workspace,
                 events_stat=events_stat,
                 core_list=f"{CORES_ALL[0]}-{CORES_ALL[-1]}",
                 count_delta_stat=count_delta_stat,


### PR DESCRIPTION
The `pipa generate` command in "run_by_pipa" mode would silently fail without generating a complete script or providing any error message. This critical bug prevented new users from completing the Quickstart guide and running their first analysis.

The root cause was a `TypeError` in the `generate()` function within `run_by_pipa.py`. The function call to `build_perf_stat_cmd` was missing the required `workspace` positional argument. This unhandled exception caused the program to terminate prematurely, resulting in a truncated script file.

This commit resolves the issue by explicitly passing the `workspace` variable to the `build_perf_stat_cmd` function. The fix ensures that the script generation process completes successfully, making the Quickstart workflow fully operational.