### PR TITLE
fix(generate): Fix dmidecode path in export script

### DIFF
--- a/src/pipa/service/export_sys_config.py
+++ b/src/pipa/service/export_sys_config.py
@@ -6,7 +6,7 @@ import os
 shell_script = """
 if [[ $(id -u) -eq 0 ]]; then
     # User is root, run dmidecode directly
-    dmidecode >/$DST/dmidecode.txt
+    dmidecode >$DST/dmidecode.txt
 else
     echo "You need to be root to run dmidecode, skipping..."
 fi


### PR DESCRIPTION
The script generated by `pipa generate` for
exporting system configuration contained an
erroneous leading slash in the file path
for the `dmidecode` output. This caused the 
script to fail with a "No such file or directory" error.

This commit removes the extraneous slash,
ensuring the output path is correctly treated as
relative to the workspace directory.